### PR TITLE
[UI] 고정폭 레이아웃/글래스 카드 적용 – 화면 축소 시 구조 유지

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,20 +4,23 @@ const HomePage = () => {
   const navigate = useNavigate();
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-white via-indigo-100 to-indigo-200 flex flex-col items-center justify-center px-6 text-center">
-      <h1 className="text-5xl font-extrabold text-gray-800 mb-4">
-        Welcome to <span className="text-indigo-600">Social Login</span> Demo
-      </h1>
-      <p className="text-lg text-gray-600 mb-10">
-        다양한 소셜 계정으로 간편하게 로그인해보세요.
-      </p>
+    <div className="min-h-screen w-screen overflow-x-auto bg-gradient-to-b from-white via-indigo-100 to-indigo-200">
+      <div className="w-[640px] mx-auto min-h-screen flex flex-col items-center justify-center px-6 text-center shrink-0">
+        <h1 className="text-5xl font-extrabold text-gray-800 mb-4 whitespace-nowrap shrink-0">
+          Welcome to <span className="text-indigo-600">Social Login</span> Demo
+        </h1>
 
-      <button
-        onClick={() => navigate("/login")}
-        className="px-6 py-3 bg-indigo-600 text-white text-lg font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition"
-      >
-        로그인하러 가기 →
-      </button>
+        <p className="text-lg text-gray-600 mb-10 shrink-0">
+          다양한 소셜 계정으로 간편하게 로그인해보세요.
+        </p>
+
+        <button
+          onClick={() => navigate("/login")}
+          className="w-[240px] h-[52px] bg-indigo-600 text-white text-lg font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition shrink-0"
+        >
+          로그인하러 가기 →
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -13,38 +13,48 @@ const LoginPage = () => {
   const { handleSuccess, handleFail } = useKakaoLogin();
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-white via-indigo-100 to-indigo-200 flex flex-col items-center justify-center px-6 text-center gap-2">
-      <h1 className="text-4xl font-extrabold text-gray-800 mb-2">
-        Social Login
-      </h1>
-      <p className="text-gray-600 mb-8 text-base">
-        원하는 소셜 계정으로 로그인 해보세요
-      </p>
-      <div className="flex flex-col gap-4">
-        {/* 구글 로그인 */}
-        <button
-          onClick={handleGoogleLogin}
-          className="flex items-center justify-center gap-3 w-[20rem] h-[3.5rem] rounded-md bg-[#006aff85] text-black font-medium text-base cursor-pointer hover:opacity-90 transition-all"
-        >
-          <img src={google} alt="구글 로고" className="w-5 h-5" />
-          <span className="font-black">구글 로그인</span>
-        </button>
+    <div className="min-h-screen w-screen overflow-x-auto bg-gradient-to-b from-white via-indigo-100 to-indigo-200">
+      <div className="w-[640px] mx-auto min-h-screen flex flex-col items-center justify-center px-6 text-center gap-2 shrink-0">
+        <h1 className="text-4xl font-extrabold text-gray-800 mb-2 whitespace-nowrap shrink-0">
+          Social Login
+        </h1>
 
-        {/* 카카오 로그인 */}
-        <KakaoLogin
-          token={kakaoClientId}
-          onSuccess={handleSuccess}
-          onFail={handleFail}
-          render={({ onClick }) => (
-            <button
-              onClick={onClick}
-              className="flex items-center justify-center gap-1 w-[20rem] h-[3.5rem] rounded-md bg-[#FEE500] text-black font-medium text-base cursor-pointer hover:opacity-90 transition-all"
-            >
-              <img src={kakao} alt="카카오 로고" className="w-9 h-9" />
-              <span className="font-black">카카오 로그인</span>
-            </button>
-          )}
-        />
+        <p className="text-gray-600 mb-8 text-base whitespace-nowrap shrink-0">
+          원하는 소셜 계정으로 로그인 해보세요
+        </p>
+
+        <div className="flex flex-col gap-4 items-center shrink-0">
+          {/* 구글 로그인 */}
+          <button
+            onClick={handleGoogleLogin}
+            className="flex items-center justify-center gap-3 min-w-[20rem] w-[20rem] h-[3.5rem] rounded-md bg-[#006aff85] text-black font-medium text-base cursor-pointer hover:opacity-90 transition-all shrink-0"
+          >
+            <img src={google} alt="구글 로고" className="w-5 h-5 shrink-0" />
+            <span className="font-black whitespace-nowrap">구글 로그인</span>
+          </button>
+
+          {/* 카카오 로그인 */}
+          <KakaoLogin
+            token={kakaoClientId}
+            onSuccess={handleSuccess}
+            onFail={handleFail}
+            render={({ onClick }) => (
+              <button
+                onClick={onClick}
+                className="flex items-center justify-center gap-1 min-w-[20rem] w-[20rem] h-[3.5rem] rounded-md bg-[#FEE500] text-black font-medium text-base cursor-pointer hover:opacity-90 transition-all shrink-0"
+              >
+                <img
+                  src={kakao}
+                  alt="카카오 로고"
+                  className="w-9 h-9 shrink-0"
+                />
+                <span className="font-black whitespace-nowrap">
+                  카카오 로그인
+                </span>
+              </button>
+            )}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -27,7 +27,7 @@ const LoginPage = () => {
           {/* 구글 로그인 */}
           <button
             onClick={handleGoogleLogin}
-            className="flex items-center justify-center gap-3 min-w-[20rem] w-[20rem] h-[3.5rem] rounded-md bg-[#006aff85] text-black font-medium text-base cursor-pointer hover:opacity-90 transition-all shrink-0"
+            className="flex items-center justify-center gap-3 min-w-[20rem] w-[20rem] h-[3.5rem] rounded-md bg-[#0084ff51] text-black font-medium text-base cursor-pointer hover:opacity-90 transition-all shrink-0"
           >
             <img src={google} alt="구글 로고" className="w-5 h-5 shrink-0" />
             <span className="font-black whitespace-nowrap">구글 로그인</span>

--- a/src/pages/MyPageGoogle.tsx
+++ b/src/pages/MyPageGoogle.tsx
@@ -84,13 +84,8 @@ const MyPageGoogle = () => {
             <span className="bg-gradient-to-r from-indigo-600 via-fuchsia-600 to-rose-500 bg-clip-text text-transparent">
               {user.name}
             </span>
-            <span className="text-gray-800"> 님, 환영합니다 🎉</span>
+            <span className="text-gray-800">님, 환영합니다 🎉</span>
           </h1>
-          {user.bio && (
-            <p className="text-sm text-gray-700/90 text-center leading-relaxed whitespace-pre-line">
-              {user.bio}
-            </p>
-          )}
           <button
             onClick={handleLogout}
             className="mt-2 h-11 px-5 rounded-xl bg-red-400 text-white font-semibold shadow-md hover:shadow-lg hover:bg-red-600 active:scale-[0.98] transition"

--- a/src/pages/MyPageGoogle.tsx
+++ b/src/pages/MyPageGoogle.tsx
@@ -70,23 +70,42 @@ const MyPageGoogle = () => {
   if (!user) return null;
 
   return (
-    <div className="h-screen flex flex-col items-center justify-center gap-4">
-      <h2 className="text-gray-500 text-sm">프로필</h2>
-      <img
-        src={user.avatar}
-        alt="프로필 이미지"
-        className="w-24 h-24 rounded-full border object-cover"
-      />
-      <h1 className="text-xl font-bold">{user.name}님, 환영합니다 🎉</h1>
-      <p className="text-sm text-gray-600">{user.bio}</p>
-
-      {/* 로그아웃 버튼 */}
-      <button
-        onClick={handleLogout}
-        className="mt-4 bg-red-400 px-4 py-2 rounded text-white hover:bg-red-600 transition"
-      >
-        로그아웃
-      </button>
+    <div className="relative min-h-screen w-screen overflow-x-auto bg-gradient-to-b from-white via-indigo-100 to-indigo-200">
+      <div className="w-[560px] mx-auto min-h-screen flex items-center justify-center p-8 shrink-0">
+        <div className="relative w-full rounded-3xl border border-white/40 bg-white/70 backdrop-blur-xl shadow-2xl p-10 flex flex-col items-center gap-6">
+          <div className="pointer-events-none absolute -top-8 left-1/2 h-16 w-56 -translate-x-1/2 rounded-full bg-white/60 blur-2xl" />
+          <h2 className="text-gray-500 text-sm whitespace-nowrap">프로필</h2>
+          <img
+            src={user.avatar}
+            alt="프로필 이미지"
+            className="w-28 h-28 rounded-full object-cover shadow-lg ring-4 ring-indigo-200 ring-offset-4 ring-offset-white"
+          />
+          <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight text-gray-900 whitespace-nowrap">
+            <span className="bg-gradient-to-r from-indigo-600 via-fuchsia-600 to-rose-500 bg-clip-text text-transparent">
+              {user.name}
+            </span>
+            <span className="text-gray-800"> 님, 환영합니다 🎉</span>
+          </h1>
+          {user.bio && (
+            <p className="text-sm text-gray-700/90 text-center leading-relaxed whitespace-pre-line">
+              {user.bio}
+            </p>
+          )}
+          <button
+            onClick={handleLogout}
+            className="mt-2 h-11 px-5 rounded-xl bg-red-400 text-white font-semibold shadow-md hover:shadow-lg hover:bg-red-600 active:scale-[0.98] transition"
+          >
+            로그아웃
+          </button>
+          <div className="mt-3 text-[11px] text-gray-500 text-center">
+            안전한 사용을 위해{" "}
+            <span className="font-semibold text-gray-600">
+              이용 후 로그아웃
+            </span>
+            을 권장합니다.
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/MyPageKakao.tsx
+++ b/src/pages/MyPageKakao.tsx
@@ -49,23 +49,29 @@ const MyPageKakao = () => {
 
   // 마이페이지 화면
   return (
-    <div className="h-screen flex flex-col items-center justify-center gap-4">
-      <h2 className="text-gray-500 text-sm">카카오 프로필</h2>
-      <img
-        src={user.avatar}
-        alt="프로필 이미지"
-        className="w-24 h-24 rounded-full border object-cover"
-      />
-      <h1 className="text-xl font-bold">{user.name}님, 환영합니다 🎉</h1>
-      <p className="text-sm text-gray-600">{user.bio}</p>
-
-      {/* 로그아웃 버튼 */}
-      <button
-        onClick={handleLogout}
-        className="mt-4 bg-yellow-400 px-4 py-2 rounded text-white hover:bg-yellow-600 transition"
-      >
-        로그아웃
-      </button>
+    <div className="h-screen w-screen overflow-x-auto bg-white">
+      <div className="w-[480px] mx-auto h-screen flex flex-col items-center justify-center gap-4 shrink-0">
+        <h2 className="text-gray-500 text-sm whitespace-nowrap shrink-0">
+          카카오 프로필
+        </h2>
+        <img
+          src={user.avatar}
+          alt="프로필 이미지"
+          className="w-24 h-24 rounded-full border object-cover shrink-0"
+        />
+        <h1 className="text-xl font-bold whitespace-nowrap shrink-0">
+          {user.name}님, 환영합니다 🎉
+        </h1>
+        <p className="text-sm text-gray-600 whitespace-nowrap shrink-0">
+          {user.bio}
+        </p>
+        <button
+          onClick={handleLogout}
+          className="mt-4 bg-yellow-400 px-4 py-2 rounded text-white hover:bg-yellow-600 transition shrink-0"
+        >
+          로그아웃
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/pages/MyPageKakao.tsx
+++ b/src/pages/MyPageKakao.tsx
@@ -53,7 +53,7 @@ const MyPageKakao = () => {
       <div className="w-[560px] mx-auto min-h-screen flex items-center justify-center p-8 shrink-0">
         <div className="relative w-full rounded-3xl border border-white/40 bg-white/70 backdrop-blur-xl shadow-2xl p-10 flex flex-col items-center gap-6">
           <div className="pointer-events-none absolute -top-8 left-1/2 h-16 w-56 -translate-x-1/2 rounded-full bg-white/60 blur-2xl" />
-          <h2 className="text-gray-500 text-sm whitespace-nowrap">내 프로필</h2>
+          <h2 className="text-gray-500 text-sm whitespace-nowrap">프로필</h2>
           <img
             src={user.avatar}
             alt="프로필 이미지"

--- a/src/pages/MyPageKakao.tsx
+++ b/src/pages/MyPageKakao.tsx
@@ -49,28 +49,41 @@ const MyPageKakao = () => {
 
   // 마이페이지 화면
   return (
-    <div className="h-screen w-screen overflow-x-auto bg-white">
-      <div className="w-[480px] mx-auto h-screen flex flex-col items-center justify-center gap-4 shrink-0">
-        <h2 className="text-gray-500 text-sm whitespace-nowrap shrink-0">
-          카카오 프로필
-        </h2>
-        <img
-          src={user.avatar}
-          alt="프로필 이미지"
-          className="w-24 h-24 rounded-full border object-cover shrink-0"
-        />
-        <h1 className="text-xl font-bold whitespace-nowrap shrink-0">
-          {user.name}님, 환영합니다 🎉
-        </h1>
-        <p className="text-sm text-gray-600 whitespace-nowrap shrink-0">
-          {user.bio}
-        </p>
-        <button
-          onClick={handleLogout}
-          className="mt-4 bg-yellow-400 px-4 py-2 rounded text-white hover:bg-yellow-600 transition shrink-0"
-        >
-          로그아웃
-        </button>
+    <div className="relative min-h-screen w-screen overflow-x-auto bg-gradient-to-b from-white via-indigo-100 to-indigo-200">
+      <div className="w-[560px] mx-auto min-h-screen flex items-center justify-center p-8 shrink-0">
+        <div className="relative w-full rounded-3xl border border-white/40 bg-white/70 backdrop-blur-xl shadow-2xl p-10 flex flex-col items-center gap-6">
+          <div className="pointer-events-none absolute -top-8 left-1/2 h-16 w-56 -translate-x-1/2 rounded-full bg-white/60 blur-2xl" />
+          <h2 className="text-gray-500 text-sm whitespace-nowrap">내 프로필</h2>
+          <img
+            src={user.avatar}
+            alt="프로필 이미지"
+            className="w-28 h-28 rounded-full object-cover shadow-lg ring-4 ring-indigo-200 ring-offset-4 ring-offset-white"
+          />
+          <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight text-gray-900 whitespace-nowrap">
+            <span className="bg-gradient-to-r from-indigo-600 via-fuchsia-600 to-rose-500 bg-clip-text text-transparent">
+              {user.name}
+            </span>
+            <span className="text-gray-800"> 님, 환영합니다 🎉</span>
+          </h1>
+          {user.bio && (
+            <p className="text-sm text-gray-700/90 text-center leading-relaxed whitespace-pre-line">
+              {user.bio}
+            </p>
+          )}
+          <button
+            onClick={handleLogout}
+            className="mt-2 h-11 px-5 rounded-xl bg-yellow-400 text-white font-semibold shadow-md hover:shadow-lg hover:bg-yellow-500 active:scale-[0.98] transition"
+          >
+            로그아웃
+          </button>
+          <div className="mt-3 text-[11px] text-gray-500 text-center">
+            안전한 사용을 위해{" "}
+            <span className="font-semibold text-gray-600">
+              이용 후 로그아웃
+            </span>
+            을 권장합니다.
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/MyPageKakao.tsx
+++ b/src/pages/MyPageKakao.tsx
@@ -63,13 +63,8 @@ const MyPageKakao = () => {
             <span className="bg-gradient-to-r from-indigo-600 via-fuchsia-600 to-rose-500 bg-clip-text text-transparent">
               {user.name}
             </span>
-            <span className="text-gray-800"> 님, 환영합니다 🎉</span>
+            <span className="text-gray-800">님, 환영합니다 🎉</span>
           </h1>
-          {user.bio && (
-            <p className="text-sm text-gray-700/90 text-center leading-relaxed whitespace-pre-line">
-              {user.bio}
-            </p>
-          )}
           <button
             onClick={handleLogout}
             className="mt-2 h-11 px-5 rounded-xl bg-yellow-400 text-white font-semibold shadow-md hover:shadow-lg hover:bg-yellow-500 active:scale-[0.98] transition"


### PR DESCRIPTION
### ✅ 관련 이슈번호

- Closed #1

---


### 📌 개요
- Homepage, LoginPage, MyPageGoogle, MyPageKakao 페이지의 레이아웃을 개선
- 화면을 줄여도 버튼/텍스트가 줄바꿈되거나 구조가 일그러지지 않도록 고정 폭 + 가로 스크롤 허용 패턴으로 통일
- 단순한 보여주기식 UI에서 글래스 카드 + 그라디언트 배경으로 스타일링을 개선

---

### ⭐ 변경 사항
- 공통
  - 부모 컨테이너에 overflow-x-auto 적용, 내부 패널 w-[560px] + shrink-0로 축소 방지
  - 타이포 정리 및 여백·정렬 통일, 액션 버튼 인터랙션(hover/active) 강화

- `Homepage` / `LoginPage`
  - 버튼, 헤더 텍스트 크기 고정 및 whitespace-nowrap 적용(필요 구간)
  
- `MyPageGoogle` / `MyPageKakao`
  - 글래스 카드(bg-white/70 + backdrop-blur-xl + border-white/40 + shadow-2xl)
  - 헤더 카피 정리(“프로필”), 이름 그라디언트 강조
  - 로그아웃 권장 멘트 추가
  - 색상 규칙 유지: Google은 빨간색 로그아웃, Kakao는 노란색 로그아웃

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="1918" height="905" alt="스크린샷 2025-08-27 201638" src="https://github.com/user-attachments/assets/bfca5758-a97e-4621-8673-8127d465d93a" />
<img width="1918" height="907" alt="스크린샷 2025-08-27 201703" src="https://github.com/user-attachments/assets/8881c32c-bc1a-496a-a387-f9c44824df57" />
<img width="1918" height="907" alt="google" src="https://github.com/user-attachments/assets/a458a272-d1d1-4297-bfb2-eb951ab2521f" />
<img width="1918" height="907" alt="kakao" src="https://github.com/user-attachments/assets/d2949d0c-0de5-4d54-8df7-edc0f9e59077" />

